### PR TITLE
refactor: RedisConfig 하드 코딩 제거 

### DIFF
--- a/src/main/java/org/example/staystylish/domain/localweather/config/RedisConfig.java
+++ b/src/main/java/org/example/staystylish/domain/localweather/config/RedisConfig.java
@@ -1,26 +1,43 @@
 package org.example.staystylish.domain.localweather.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-
-/**
- * RedisConnectionFactory Bean - Redis 서버(host=localhost, port=6379) 연결 정보 설정 - LettuceConnectionFactory 사용: 비동기/논블로킹
- * Redis 클라이언트
- */
+import org.springframework.util.StringUtils;
 
 @Configuration
 @EnableCaching
 public class RedisConfig {
 
+    // application.yml 또는 Parameter Store 등에서 설정값 주입 받기
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Value("${spring.data.redis.password:#{null}}")
+    private String redisPassword;
+
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory("localhost", 6379);
+        // RedisStandaloneConfiguration 사용하여 호스트, 포트, 비밀번호 설정
+        RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(redisHost, redisPort);
+
+        // 비밀번호가 설정되어 있을 경우에만 설정
+        if (StringUtils.hasText(redisPassword)) {
+            redisConfig.setPassword(redisPassword);
+        }
+
+        return new LettuceConnectionFactory(redisConfig); // 설정 객체로 LettuceConnectionFactory 생성
     }
 
     /**


### PR DESCRIPTION
## 🔗 **연관된 이슈**
> close #76 

<br>

## 📝 **작업 내용**

- Redis 연결 정보를 하드코딩하는 대신 https://github.com/value 어노테이션을 사용하여 Spring 환경 설정
에서 값을 주입받도록 수정

<br>

## 📸 **스크린샷 (Optional)**

<br>